### PR TITLE
feat: added docker caching

### DIFF
--- a/build-push/action.yml
+++ b/build-push/action.yml
@@ -223,12 +223,16 @@ runs:
         file: ${{ inputs.dockerfile-path }}
         platforms: ${{ inputs.buildx-platforms }}
         tags: ${{ env.DOCKER_TAGS }}
+        cache-from: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:buildcache
+        cache-to: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:buildcache,mode=max
         push: true
         build-args: ${{ inputs.build-args }}
       env:
         DOCKER_BUILDKIT: 1
         DOCKER_USERNAME: ${{ inputs.dockerhub-username }}
         DOCKER_PASSWORD: ${{ inputs.dockerhub-token }}
+        IMG_OWNER: ${{ inputs.docker-image-owner }}
+        IMG_NAME: ${{ inputs.docker-image-name }}
 
     - name: Build and Push FIPS Docker Image
       if: ${{ inputs.fips-docker-file-path != '' }}
@@ -238,9 +242,13 @@ runs:
         file: ${{ inputs.fips-docker-file-path }}
         platforms: ${{ inputs.buildx-platforms }}
         tags: ${{ env.DOCKER_TAGS_FIPS }}
+        cache-from: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}-fips:buildcache
+        cache-to: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}-fips:buildcache,mode=max
         push: true
         build-args: ${{ inputs.build-args }}
       env:
         DOCKER_BUILDKIT: 1
         DOCKER_USERNAME: ${{ inputs.dockerhub-username }}
         DOCKER_PASSWORD: ${{ inputs.dockerhub-token }}
+        IMG_OWNER: ${{ inputs.docker-image-owner }}
+        IMG_NAME: ${{ inputs.docker-image-name }}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This pull request updates the Docker build and push GitHub Action to improve build caching and environment variable handling. The main changes add support for remote build cache storage, which should speed up subsequent builds, and ensure that image owner and name variables are available during the build process.

**Enhancements to Docker build and push process:**

* Added `cache-from` and `cache-to` options to both the standard and FIPS Docker image build steps, enabling the use of a remote build cache stored in the registry for faster builds. 

**Environment variable improvements:**

* Set `IMG_OWNER` and `IMG_NAME` environment variables in both build steps to ensure the cache references are constructed correctly. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->