### PR TITLE
feat: add build-push secret passthrough inputs

### DIFF
--- a/build-push/README.md
+++ b/build-push/README.md
@@ -14,7 +14,7 @@ A reusable GitHub Action for building and pushing Docker images to both DockerHu
 
 ```yaml
 - name: Build and Push Docker Image
-  uses: makeplane/actions/build-push@v1.0.0
+  uses: makeplane/actions/build-push@main
   with:
     # Required Parameters
     dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -29,7 +29,12 @@ A reusable GitHub Action for building and pushing Docker images to both DockerHu
     buildx-version: "latest"
     buildx-platforms: "linux/amd64"
     buildx-endpoint: "default"
+    secrets: ""
+    secret-envs: ""
+    secret-files: ""
 ```
+
+Use a published tag in production workflows. Examples in this README use `@main` so they match the unreleased inputs documented on the default branch.
 
 ### Inputs
 
@@ -56,6 +61,9 @@ A reusable GitHub Action for building and pushing Docker images to both DockerHu
 | `build-context` | Build context path | No | `"."` |
 | `dockerfile-path` | Path to Dockerfile | Yes | - |
 | `build-args` | Build arguments | No | `""` |
+| `secrets` | BuildKit inline secrets | No | `""` |
+| `secret-envs` | BuildKit environment-backed secrets | No | `""` |
+| `secret-files` | BuildKit file-backed secrets | No | `""` |
 
 #### Buildx Options
 | Input | Description | Required | Default |
@@ -103,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build and Push
-        uses: makeplane/actions/build-push@v1.0.0
+        uses: makeplane/actions/build-push@main
         with:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -119,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build and Push Release
-        uses: makeplane/actions/build-push@v1.0.0
+        uses: makeplane/actions/build-push@main
         with:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -129,4 +137,26 @@ jobs:
           build-release: "true"
           release-version: "v1.0.0"
           buildx-platforms: "linux/amd64,linux/arm64"
+```
+
+#### BuildKit Secrets
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build with BuildKit secrets
+        uses: makeplane/actions/build-push@main
+        with:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: myorg
+          docker-image-name: myapp
+          dockerfile-path: ./Dockerfile
+          secret-envs: |
+            sentry_auth_token=SENTRY_AUTH_TOKEN
+          secret-files: |
+            npmrc=.npmrc
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 ```

--- a/build-push/action.yml
+++ b/build-push/action.yml
@@ -50,6 +50,18 @@ inputs:
     description: "The build arguments"
     required: false
     default: ""
+  secrets:
+    description: "BuildKit secrets to expose to the build"
+    required: false
+    default: ""
+  secret-envs:
+    description: "Environment-backed BuildKit secrets to expose to the build"
+    required: false
+    default: ""
+  secret-files:
+    description: "File-backed BuildKit secrets to expose to the build"
+    required: false
+    default: ""
 
   # Buildx Options
   buildx-driver:
@@ -111,6 +123,7 @@ runs:
         IS_PRERELEASE: ${{ inputs.build-prerelease }}
         REL_VERSION: ${{ inputs.release-version }}
         FIPS_DOCKER_FILE_PATH: ${{ inputs.fips-docker-file-path }}
+        TARGET_BRANCH: ${{ github.ref_name }}
       run: |
         FLAT_BRANCH_VERSION=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9.-]//g')
         IMG_NAME_FIPS="${{ env.IMG_NAME }}-fips"
@@ -179,28 +192,28 @@ runs:
         fi
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4.0.0
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-token}}
 
     - name: Login to Private Registry
       if: ${{ inputs.private-registry-push == 'true' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4.0.0
       with:
         username: ${{ inputs.private-registry-username }}
         password: ${{ inputs.private-registry-token }}
         registry: ${{ inputs.private-registry-addr }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4.0.0
       with:
         driver: ${{ inputs.buildx-driver }}
         version: ${{ inputs.buildx-version }}
         endpoint: ${{ inputs.buildx-endpoint }}
 
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
 
     - name: Copy License
       if: ${{ inputs.copy-license == 'true' }}
@@ -210,14 +223,14 @@ runs:
 
     - name: Download Additional Assets
       if: ${{ inputs.additional-assets != '' && inputs.additional-assets-dir != '' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.1
       with:
         name: ${{ inputs.additional-assets }}
         path: ${{ inputs.additional-assets-dir }}
 
 
     - name: Build and Push Docker Image
-      uses: docker/build-push-action@v5.1.0
+      uses: docker/build-push-action@v6.18.0
       with:
         context: ${{ inputs.build-context }}
         file: ${{ inputs.dockerfile-path }}
@@ -227,6 +240,9 @@ runs:
         cache-to: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:buildcache,mode=max
         push: true
         build-args: ${{ inputs.build-args }}
+        secrets: ${{ inputs.secrets }}
+        secret-envs: ${{ inputs.secret-envs }}
+        secret-files: ${{ inputs.secret-files }}
       env:
         DOCKER_BUILDKIT: 1
         DOCKER_USERNAME: ${{ inputs.dockerhub-username }}
@@ -236,7 +252,7 @@ runs:
 
     - name: Build and Push FIPS Docker Image
       if: ${{ inputs.fips-docker-file-path != '' }}
-      uses: docker/build-push-action@v5.1.0
+      uses: docker/build-push-action@v6.18.0
       with:
         context: ${{ inputs.build-context }}
         file: ${{ inputs.fips-docker-file-path }}
@@ -246,6 +262,9 @@ runs:
         cache-to: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}-fips:buildcache,mode=max
         push: true
         build-args: ${{ inputs.build-args }}
+        secrets: ${{ inputs.secrets }}
+        secret-envs: ${{ inputs.secret-envs }}
+        secret-files: ${{ inputs.secret-files }}
       env:
         DOCKER_BUILDKIT: 1
         DOCKER_USERNAME: ${{ inputs.dockerhub-username }}


### PR DESCRIPTION
## Summary
- add BuildKit secret passthrough inputs to the build-push action: secrets, secret-envs, and secret-files
- update the action internals to newer dependency versions and fix branch tag detection by setting TARGET_BRANCH
- refresh the README examples to cover the new inputs and unreleased default-branch usage

## Consumer PR
- plane-ee integration example: https://github.com/makeplane/plane-ee/pull/6539

## Validation
- ruby -e "require "yaml"; YAML.load_file("build-push/action.yml"); puts "ok""
- git diff --check