### PR TITLE
fix: update Docker build-push action to v7.0.0 and improve tag handling

### DIFF
--- a/build-push/action.yml
+++ b/build-push/action.yml
@@ -230,7 +230,7 @@ runs:
 
 
     - name: Build and Push Docker Image
-      uses: docker/build-push-action@v6.18.0
+      uses: docker/build-push-action@v7.0.0
       with:
         context: ${{ inputs.build-context }}
         file: ${{ inputs.dockerfile-path }}
@@ -252,7 +252,7 @@ runs:
 
     - name: Build and Push FIPS Docker Image
       if: ${{ inputs.fips-docker-file-path != '' }}
-      uses: docker/build-push-action@v6.18.0
+      uses: docker/build-push-action@v7.0.0
       with:
         context: ${{ inputs.build-context }}
         file: ${{ inputs.fips-docker-file-path }}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This pull request updates the Docker build and push steps in the `build-push/action.yml` workflow to use a newer version of the Docker GitHub Action. The main change is upgrading from version 6.18.0 to 7.0.0 for both standard and FIPS Docker image builds.


### Type of Change
<!-- Put an 'x' in the boxes that apply -->

- [X] Improvement (change that would cause existing functionality to not work as expected)


