### PR TITLE
feat: split-architecture digest builds and manifest merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Build and push Docker images to DockerHub and private registries with support fo
 - Smart tagging system for releases
 - Private registry support
 - Build arguments and more
+- Split-architecture builds that push by digest, for merging with `merge-manifest`
+
+### [Merge Multi-Arch Manifest](./merge-manifest)
+Collects the per-architecture digests produced by `build-push` and publishes them
+as a single tagged multi-arch manifest. Together the two actions let one image be
+built by several jobs in parallel, each on a runner native to its architecture,
+with no QEMU emulation and no remote builder.
+
+## Shared tag policy
+
+Both actions derive their tags from [`scripts/compute-tags.sh`](./scripts/compute-tags.sh).
+Keep it that way: if the merge re-implemented the release/master/branch regimes
+separately, drift would silently publish images under tags that release notes and
+compose files do not reference.
 
 ## Usage
 

--- a/build-push/README.md
+++ b/build-push/README.md
@@ -86,6 +86,20 @@ Use a published tag in production workflows. Examples in this README use `@main`
 | `additional-assets` | Additional assets to include | No | `""` |
 | `additional-assets-dir` | Additional assets directory path | No | `""` |
 
+#### Split-Architecture Options
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `push-by-digest` | Push an untagged manifest and return its digest instead of tags | No | `"false"` |
+| `cache-scope-suffix` | Appended to the registry cache ref (`<image>:buildcache<suffix>`) | No | `""` |
+| `digest-artifact-name` | Artifact name to upload the resulting digest under | No | `""` |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `digest` | Digest of the pushed manifest. Only set when `push-by-digest` is `true`. |
+| `tags` | Comma-separated tag list computed for this image. |
+| `image-ref` | Bare `<owner>/<name>` repository reference, with no tag. |
 
 ### Tag Generation
 
@@ -160,3 +174,63 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 ```
+
+#### Split-Architecture Build (native runners, no emulation)
+
+Build each architecture on a runner native to it, then merge the results into one
+multi-arch manifest with [`merge-manifest`](../merge-manifest). This avoids QEMU
+emulation and removes any dependency on a remote builder.
+
+```yaml
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - arch: arm64
+            platform: linux/arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: makeplane/actions/build-push@main
+        with:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: myorg
+          docker-image-name: myapp
+          dockerfile-path: ./Dockerfile
+          buildx-platforms: ${{ matrix.platform }}
+          push-by-digest: "true"
+          cache-scope-suffix: -${{ matrix.arch }}
+          digest-artifact-name: digest-myapp-${{ matrix.arch }}
+
+  merge:
+    needs: [build]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: makeplane/actions/merge-manifest@main
+        with:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: myorg
+          docker-image-name: myapp
+          digest-artifact-pattern: digest-myapp-*
+          expected-platforms: linux/amd64,linux/arm64
+```
+
+Three things matter here and are easy to get wrong:
+
+- **`cache-scope-suffix` is not optional in practice.** The registry cache manifest
+  is not platform-indexed, so two legs writing the same `:buildcache` ref overwrite
+  each other and roughly half of all legs go cold every run.
+- **`digest-artifact-name` must be unique per image *and* architecture.** Digests
+  travel as artifacts rather than job outputs because every matrix leg writes the
+  same job-output key — only the last leg to finish would survive, silently
+  producing a single-platform manifest.
+- **One platform per job.** `push-by-digest` rejects a comma-separated
+  `buildx-platforms`, and is incompatible with `fips-docker-file-path` (that input
+  builds a second image, which would need a second digest stream).

--- a/build-push/action.yml
+++ b/build-push/action.yml
@@ -81,6 +81,25 @@ inputs:
     required: true
     default: "default"
 
+  # Split-architecture (push-by-digest) options.
+  #
+  # These exist so one image can be built by several jobs in parallel -- one per
+  # architecture, each on a runner native to that architecture -- and merged
+  # afterwards by the merge-manifest action. Defaults reproduce the single-job,
+  # tagged-push behaviour exactly, so existing callers need no changes.
+  push-by-digest:
+    description: "Push an untagged manifest and return its digest instead of pushing tags. Requires exactly one platform in buildx-platforms; the merge-manifest action applies the tags afterwards."
+    required: false
+    default: "false"
+  cache-scope-suffix:
+    description: "Appended to the registry cache ref (<image>:buildcache<suffix>). Set this per-architecture when building one image from several jobs, otherwise the jobs overwrite each other's cache."
+    required: false
+    default: ""
+  digest-artifact-name:
+    description: "When set (with push-by-digest), the resulting digest is uploaded under this artifact name for the merge job to collect. Must be unique per image and architecture within a workflow run."
+    required: false
+    default: ""
+
   # Release Build Options
   build-release:
     description: "Flag to publish release"
@@ -108,10 +127,42 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  digest:
+    description: "Digest of the pushed manifest. Only set when push-by-digest is true."
+    value: ${{ steps.build_by_digest.outputs.digest }}
+  tags:
+    description: "Comma-separated tag list computed for this image. Pass this to merge-manifest so the merge cannot disagree with the build about tag policy."
+    value: ${{ steps.compute_tags.outputs.DOCKER_TAGS }}
+  image-ref:
+    description: "Bare <owner>/<name> repository reference, with no tag."
+    value: ${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}
+
 runs:
   using: "composite"
   steps:
+    # push-by-digest cannot express either of these, and both would fail in ways
+    # that are hard to read from a build log. Refuse up front instead.
+    - name: Validate digest-mode inputs
+      if: ${{ inputs.push-by-digest == 'true' }}
+      shell: bash
+      env:
+        BUILDX_PLATFORMS: ${{ inputs.buildx-platforms }}
+        FIPS_DOCKER_FILE_PATH: ${{ inputs.fips-docker-file-path }}
+      run: |
+        if [[ "$BUILDX_PLATFORMS" == *,* ]]; then
+          echo "push-by-digest builds exactly one platform per job, got: ${BUILDX_PLATFORMS}" >&2
+          echo "Give each architecture its own job and merge them with merge-manifest." >&2
+          exit 1
+        fi
+        if [ -n "$FIPS_DOCKER_FILE_PATH" ]; then
+          echo "push-by-digest does not support fips-docker-file-path." >&2
+          echo "That input builds a second image, which would need a second digest stream." >&2
+          exit 1
+        fi
+
     - name: Set Docker Tag
+      id: compute_tags
       shell: bash
       env:
         IMG_OWNER: ${{ inputs.docker-image-owner }}
@@ -124,72 +175,7 @@ runs:
         REL_VERSION: ${{ inputs.release-version }}
         FIPS_DOCKER_FILE_PATH: ${{ inputs.fips-docker-file-path }}
         TARGET_BRANCH: ${{ github.ref_name }}
-      run: |
-        FLAT_BRANCH_VERSION=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9.-]//g')
-        IMG_NAME_FIPS="${{ env.IMG_NAME }}-fips"
-
-        if [ "${{ env.BUILD_RELEASE }}" == "true" ]; then
-          semver_regex="^v([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)?$"
-          if [[ ! ${{ env.REL_VERSION }} =~ $semver_regex ]]; then
-            echo "Invalid Release Version Format : ${{ env.REL_VERSION }}"
-            echo "Please provide a valid SemVer version"
-            echo "e.g. v1.2.3 or v1.2.3-alpha-1"
-            echo "Exiting the build process"
-            exit 1  # Exit with status 1 to fail the step
-          fi
-
-          TAG=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:${{ env.REL_VERSION }}
-
-          if [ "${{ env.PRIVATE_REGISTRY_PUSH }}" == "true" ]; then
-            TAG=${TAG},${{ env.PRIVATE_REGISTRY_ADDR }}/${{ env.PRIVATE_REGISTRY_PROJECT }}/${{ env.IMG_NAME }}:${{ env.REL_VERSION }}
-          fi
-
-          if [ "${{ env.IS_PRERELEASE }}" != "true" ]; then
-            TAG=${TAG},${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:stable
-            if [ "${{ env.PRIVATE_REGISTRY_PUSH }}" == "true" ]; then
-              TAG=${TAG},${{ env.PRIVATE_REGISTRY_ADDR }}/${{ env.PRIVATE_REGISTRY_PROJECT }}/${{ env.IMG_NAME }}:stable
-            fi
-          fi
-        elif [ "${{ env.TARGET_BRANCH }}" == "master" ]; then
-          TAG=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:latest
-          if [ "${{ env.PRIVATE_REGISTRY_PUSH }}" == "true" ]; then
-            TAG=${TAG},${{ env.PRIVATE_REGISTRY_ADDR }}/${{ env.PRIVATE_REGISTRY_PROJECT }}/${{ env.IMG_NAME }}:latest
-          fi
-        else
-          TAG=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:${FLAT_BRANCH_VERSION}
-          if [ "${{ env.PRIVATE_REGISTRY_PUSH }}" == "true" ]; then
-            TAG=${TAG},${{ env.PRIVATE_REGISTRY_ADDR }}/${{ env.PRIVATE_REGISTRY_PROJECT }}/${{ env.IMG_NAME }}:${FLAT_BRANCH_VERSION}
-          fi
-        fi
-
-        echo "DOCKER_TAGS=${TAG}" >> $GITHUB_ENV
-
-        # When FIPS Dockerfile path is set, compute FIPS tags (image name suffixed with -fips)
-        if [ -n "${{ env.FIPS_DOCKER_FILE_PATH }}" ]; then
-          if [ "${{ env.BUILD_RELEASE }}" == "true" ]; then
-            TAG_FIPS=${{ env.IMG_OWNER }}/${IMG_NAME_FIPS}:${{ env.REL_VERSION }}
-            if [ "${{ env.PRIVATE_REGISTRY_PUSH }}" == "true" ]; then
-              TAG_FIPS=${TAG_FIPS},${{ env.PRIVATE_REGISTRY_ADDR }}/${{ env.PRIVATE_REGISTRY_PROJECT }}/${IMG_NAME_FIPS}:${{ env.REL_VERSION }}
-            fi
-            if [ "${{ env.IS_PRERELEASE }}" != "true" ]; then
-              TAG_FIPS=${TAG_FIPS},${{ env.IMG_OWNER }}/${IMG_NAME_FIPS}:stable
-              if [ "${{ env.PRIVATE_REGISTRY_PUSH }}" == "true" ]; then
-                TAG_FIPS=${TAG_FIPS},${{ env.PRIVATE_REGISTRY_ADDR }}/${{ env.PRIVATE_REGISTRY_PROJECT }}/${IMG_NAME_FIPS}:stable
-              fi
-            fi
-          elif [ "${{ env.TARGET_BRANCH }}" == "master" ]; then
-            TAG_FIPS=${{ env.IMG_OWNER }}/${IMG_NAME_FIPS}:latest
-            if [ "${{ env.PRIVATE_REGISTRY_PUSH }}" == "true" ]; then
-              TAG_FIPS=${TAG_FIPS},${{ env.PRIVATE_REGISTRY_ADDR }}/${{ env.PRIVATE_REGISTRY_PROJECT }}/${IMG_NAME_FIPS}:latest
-            fi
-          else
-            TAG_FIPS=${{ env.IMG_OWNER }}/${IMG_NAME_FIPS}:${FLAT_BRANCH_VERSION}
-            if [ "${{ env.PRIVATE_REGISTRY_PUSH }}" == "true" ]; then
-              TAG_FIPS=${TAG_FIPS},${{ env.PRIVATE_REGISTRY_ADDR }}/${{ env.PRIVATE_REGISTRY_PROJECT }}/${IMG_NAME_FIPS}:${FLAT_BRANCH_VERSION}
-            fi
-          fi
-          echo "DOCKER_TAGS_FIPS=${TAG_FIPS}" >> $GITHUB_ENV
-        fi
+      run: bash "${{ github.action_path }}/../scripts/compute-tags.sh"
 
     - name: Login to Docker Hub
       uses: docker/login-action@v4.0.0
@@ -218,8 +204,10 @@ runs:
     - name: Copy License
       if: ${{ inputs.copy-license == 'true' }}
       shell: bash
+      env:
+        BUILD_CONTEXT: ${{ inputs.build-context }}
       run: |
-        cp LICENSE.txt ${{ inputs.build-context }}/LICENSE.txt
+        cp LICENSE.txt "${BUILD_CONTEXT}/LICENSE.txt"
 
     - name: Download Additional Assets
       if: ${{ inputs.additional-assets != '' && inputs.additional-assets-dir != '' }}
@@ -228,16 +216,16 @@ runs:
         name: ${{ inputs.additional-assets }}
         path: ${{ inputs.additional-assets-dir }}
 
-
     - name: Build and Push Docker Image
+      if: ${{ inputs.push-by-digest != 'true' }}
       uses: docker/build-push-action@v7.0.0
       with:
         context: ${{ inputs.build-context }}
         file: ${{ inputs.dockerfile-path }}
         platforms: ${{ inputs.buildx-platforms }}
         tags: ${{ env.DOCKER_TAGS }}
-        cache-from: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:buildcache
-        cache-to: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}:buildcache,mode=max
+        cache-from: type=registry,ref=${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}:buildcache${{ inputs.cache-scope-suffix }}
+        cache-to: type=registry,ref=${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}:buildcache${{ inputs.cache-scope-suffix }},mode=max
         push: true
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.secrets }}
@@ -247,8 +235,58 @@ runs:
         DOCKER_BUILDKIT: 1
         DOCKER_USERNAME: ${{ inputs.dockerhub-username }}
         DOCKER_PASSWORD: ${{ inputs.dockerhub-token }}
-        IMG_OWNER: ${{ inputs.docker-image-owner }}
-        IMG_NAME: ${{ inputs.docker-image-name }}
+
+    # Digest mode. No tag is written here at all: the image exporter pushes the
+    # manifest and the registry hands back its digest, which merge-manifest
+    # later collects alongside the other architectures' digests. provenance is
+    # pinned off so each job pushes a plain manifest rather than an index.
+    - name: Build and Push Docker Image by Digest
+      id: build_by_digest
+      if: ${{ inputs.push-by-digest == 'true' }}
+      uses: docker/build-push-action@v7.0.0
+      with:
+        context: ${{ inputs.build-context }}
+        file: ${{ inputs.dockerfile-path }}
+        platforms: ${{ inputs.buildx-platforms }}
+        outputs: type=image,name=${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }},push-by-digest=true,name-canonical=true,push=true
+        cache-from: type=registry,ref=${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}:buildcache${{ inputs.cache-scope-suffix }}
+        cache-to: type=registry,ref=${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}:buildcache${{ inputs.cache-scope-suffix }},mode=max
+        provenance: false
+        push: false
+        build-args: ${{ inputs.build-args }}
+        secrets: ${{ inputs.secrets }}
+        secret-envs: ${{ inputs.secret-envs }}
+        secret-files: ${{ inputs.secret-files }}
+      env:
+        DOCKER_BUILDKIT: 1
+        DOCKER_USERNAME: ${{ inputs.dockerhub-username }}
+        DOCKER_PASSWORD: ${{ inputs.dockerhub-token }}
+
+    # The digest travels to the merge job as an artifact rather than a job
+    # output: every leg of a matrix writes the same job-output key, so only the
+    # last leg to finish would survive and the merge would quietly produce a
+    # single-platform manifest.
+    - name: Export digest
+      if: ${{ inputs.push-by-digest == 'true' && inputs.digest-artifact-name != '' }}
+      shell: bash
+      env:
+        DIGEST: ${{ steps.build_by_digest.outputs.digest }}
+      run: |
+        if [ -z "$DIGEST" ]; then
+          echo "Build produced no digest; refusing to upload an empty artifact." >&2
+          exit 1
+        fi
+        mkdir -p "${RUNNER_TEMP}/digests"
+        touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+    - name: Upload digest
+      if: ${{ inputs.push-by-digest == 'true' && inputs.digest-artifact-name != '' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.digest-artifact-name }}
+        path: ${{ runner.temp }}/digests/*
+        retention-days: 1
+        if-no-files-found: error
 
     - name: Build and Push FIPS Docker Image
       if: ${{ inputs.fips-docker-file-path != '' }}
@@ -258,8 +296,8 @@ runs:
         file: ${{ inputs.fips-docker-file-path }}
         platforms: ${{ inputs.buildx-platforms }}
         tags: ${{ env.DOCKER_TAGS_FIPS }}
-        cache-from: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}-fips:buildcache
-        cache-to: type=registry,ref=${{ env.IMG_OWNER }}/${{ env.IMG_NAME }}-fips:buildcache,mode=max
+        cache-from: type=registry,ref=${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}-fips:buildcache${{ inputs.cache-scope-suffix }}
+        cache-to: type=registry,ref=${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}-fips:buildcache${{ inputs.cache-scope-suffix }},mode=max
         push: true
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.secrets }}
@@ -269,5 +307,3 @@ runs:
         DOCKER_BUILDKIT: 1
         DOCKER_USERNAME: ${{ inputs.dockerhub-username }}
         DOCKER_PASSWORD: ${{ inputs.dockerhub-token }}
-        IMG_OWNER: ${{ inputs.docker-image-owner }}
-        IMG_NAME: ${{ inputs.docker-image-name }}

--- a/merge-manifest/README.md
+++ b/merge-manifest/README.md
@@ -1,0 +1,100 @@
+# Merge Multi-Arch Manifest GitHub Action
+
+Collects the per-architecture digests produced by
+[`build-push`](../build-push) in `push-by-digest` mode and publishes them as a
+single tagged multi-arch manifest.
+
+Pair it with a matrix of `build-push` jobs — one per architecture, each on a
+runner native to that architecture — so multi-arch images are built without QEMU
+emulation and without a remote builder.
+
+### How it works
+
+Each per-architecture job pushes an **untagged** manifest and gets back a content
+digest. No tag exists in the registry until this action runs. It then:
+
+1. Downloads every digest artifact matching `digest-artifact-pattern`.
+2. Computes the tag list using the **same** shared script `build-push` uses, so
+   the merge cannot disagree with the build about tag policy.
+3. Runs `docker buildx imagetools create` with one `-t` per tag over every
+   `<owner>/<name>@sha256:…` source, producing one OCI index tagged N times.
+4. Verifies the merged manifest actually advertises `expected-platforms`.
+
+That last step matters: a merge that produced a single-platform index still exits
+`0`, so the platform set is asserted rather than assumed.
+
+### Usage
+
+```yaml
+merge:
+  needs: [build]
+  runs-on: blacksmith-2vcpu-ubuntu-2404
+  steps:
+    - uses: makeplane/actions/merge-manifest@main
+      with:
+        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+        docker-image-owner: myorg
+        docker-image-name: myapp
+        digest-artifact-pattern: digest-myapp-*
+        expected-platforms: linux/amd64,linux/arm64
+```
+
+Use a published tag in production workflows. Examples in this README use `@main`
+so they match the unreleased inputs documented on the default branch.
+
+### Inputs
+
+#### Authentication
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `dockerhub-username` | DockerHub username | Yes | - |
+| `dockerhub-token` | DockerHub token | Yes | - |
+
+#### Image Options
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `docker-image-owner` | Docker image owner/organization | Yes | - |
+| `docker-image-name` | Docker image name | Yes | - |
+| `digest-artifact-pattern` | Artifact name pattern holding the digests, e.g. `digest-myapp-*` | Yes | - |
+| `expected-platforms` | Platforms the merged manifest must advertise. Empty skips the check. | No | `""` |
+
+#### Release Options
+
+These must match what `build-push` was given, so the merge applies exactly the
+tags the build would have applied.
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `build-release` | Enable release build | No | `"false"` |
+| `build-prerelease` | Mark as pre-release | No | `"false"` |
+| `release-version` | Release version | No | `"latest"` |
+
+#### Private Registry Options
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `private-registry-push` | **Not supported yet** — fails fast if `"true"` | No | `"false"` |
+| `private-registry-addr` | Private registry address | No | `"registry.plane.tools"` |
+| `private-registry-project` | Private registry project | No | `"plane"` |
+
+A digest is only addressable as `<repo>@sha256:…`, within the repository it was
+pushed to. Merging into a private registry therefore requires the
+per-architecture builds to have pushed by digest into *that* registry too, which
+`build-push` does not do yet. Rather than fail deep inside `imagetools create`
+with `MANIFEST_UNKNOWN`, this action refuses up front.
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `tags` | Comma-separated tag list applied to the merged manifest. |
+
+### Notes
+
+- The merge job is a fresh runner with no credentials carried over from the build
+  jobs, so it logs in again. `imagetools` talks to the registry directly and does
+  not need a buildx builder instance.
+- Between the build jobs and this one, the per-architecture manifests sit in the
+  registry untagged. Docker Hub keeps them indefinitely, but a registry whose
+  garbage collection deletes untagged artifacts could remove them out from under a
+  delayed or retried merge — keep the merge in the same workflow run.

--- a/merge-manifest/action.yml
+++ b/merge-manifest/action.yml
@@ -1,0 +1,164 @@
+name: "Merge Multi-Arch Manifest"
+description: "Collects per-architecture digests pushed by build-push (push-by-digest mode) and publishes them as a single tagged multi-arch manifest"
+inputs:
+  dockerhub-username:
+    description: "The Dockerhub username"
+    required: true
+  dockerhub-token:
+    description: "The Dockerhub Token"
+    required: true
+
+  private-registry-push:
+    description: "Not supported yet in digest mode -- a digest is only addressable within the repository it was pushed to, so the per-architecture builds would have to push to the private registry as well."
+    required: false
+    default: "false"
+  private-registry-addr:
+    description: "The private registry addresss"
+    required: false
+    default: "registry.plane.tools"
+  private-registry-project:
+    description: "The private registry project"
+    default: "plane"
+    required: false
+
+  docker-image-owner:
+    description: "The owner of the Docker image"
+    required: true
+  docker-image-name:
+    description: "The name of the Docker image"
+    required: true
+
+  digest-artifact-pattern:
+    description: "Artifact name pattern holding the per-architecture digests, e.g. digest-web-*"
+    required: true
+  expected-platforms:
+    description: "Comma-separated platforms the merged manifest must advertise, e.g. linux/amd64,linux/arm64. Verified after the merge; leave empty to skip the check."
+    required: false
+    default: ""
+
+  # Release Build Options -- must match what build-push was given, so the merge
+  # applies exactly the tags the build would have applied.
+  build-release:
+    description: "Flag to publish release"
+    required: false
+    default: "false"
+  build-prerelease:
+    description: "Flag to publish prerelease"
+    required: false
+    default: "false"
+  release-version:
+    description: "The release version"
+    required: false
+    default: "latest"
+
+outputs:
+  tags:
+    description: "Comma-separated tag list applied to the merged manifest."
+    value: ${{ steps.compute_tags.outputs.DOCKER_TAGS }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      if: ${{ inputs.private-registry-push == 'true' }}
+      shell: bash
+      run: |
+        echo "private-registry-push is not supported by merge-manifest." >&2
+        echo "A digest is only addressable as <repo>@sha256:..., so merging into" >&2
+        echo "the private registry requires the per-architecture builds to have" >&2
+        echo "pushed by digest into that registry too." >&2
+        exit 1
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4.0.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
+    - name: Download digests
+      uses: actions/download-artifact@v8
+      with:
+        pattern: ${{ inputs.digest-artifact-pattern }}
+        merge-multiple: true
+        path: ${{ runner.temp }}/digests
+
+    - name: Set Docker Tag
+      id: compute_tags
+      shell: bash
+      env:
+        IMG_OWNER: ${{ inputs.docker-image-owner }}
+        IMG_NAME: ${{ inputs.docker-image-name }}
+        PRIVATE_REGISTRY_PUSH: ${{ inputs.private-registry-push }}
+        PRIVATE_REGISTRY_ADDR: ${{ inputs.private-registry-addr }}
+        PRIVATE_REGISTRY_PROJECT: ${{ inputs.private-registry-project }}
+        BUILD_RELEASE: ${{ inputs.build-release }}
+        IS_PRERELEASE: ${{ inputs.build-prerelease }}
+        REL_VERSION: ${{ inputs.release-version }}
+        TARGET_BRANCH: ${{ github.ref_name }}
+      run: bash "${{ github.action_path }}/../scripts/compute-tags.sh"
+
+    - name: Create manifest list
+      shell: bash
+      env:
+        IMAGE_REF: ${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}
+      run: |
+        cd "${RUNNER_TEMP}/digests"
+
+        # Each file is named after the digest it carries, minus the sha256: prefix.
+        sources=()
+        for f in *; do
+          [ -e "$f" ] || continue
+          sources+=("${IMAGE_REF}@sha256:${f}")
+        done
+
+        if [ ${#sources[@]} -eq 0 ]; then
+          echo "No digests found for ${IMAGE_REF}." >&2
+          echo "Did the build jobs run with push-by-digest and a digest-artifact-name?" >&2
+          exit 1
+        fi
+
+        tag_args=()
+        IFS=',' read -r -a tags <<<"$DOCKER_TAGS"
+        for t in "${tags[@]}"; do
+          tag_args+=(-t "$t")
+        done
+
+        echo "Merging ${#sources[@]} digest(s) into ${#tags[@]} tag(s):"
+        printf '  source: %s\n' "${sources[@]}"
+        printf '  tag:    %s\n' "${tags[@]}"
+
+        docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+
+        echo "FIRST_TAG=${tags[0]}" >>"$GITHUB_ENV"
+
+    # A merge that produced a single-platform index still exits 0, so assert the
+    # platform set rather than trusting the exit code.
+    - name: Verify merged manifest
+      shell: bash
+      env:
+        EXPECTED_PLATFORMS: ${{ inputs.expected-platforms }}
+      run: |
+        inspected=$(docker buildx imagetools inspect "$FIRST_TAG")
+        echo "$inspected"
+
+        if [ -z "$EXPECTED_PLATFORMS" ]; then
+          exit 0
+        fi
+
+        # Match the rendered "Platform:  linux/arm64" lines rather than the raw
+        # JSON: checking os and architecture separately would pass an index that
+        # happens to contain both strings in different entries.
+        missing=0
+        IFS=',' read -r -a expected <<<"$EXPECTED_PLATFORMS"
+        for p in "${expected[@]}"; do
+          if ! grep -Eq "^[[:space:]]*Platform:[[:space:]]+${p}[[:space:]]*$" <<<"$inspected"; then
+            echo "Merged manifest ${FIRST_TAG} is missing platform ${p}" >&2
+            missing=1
+          fi
+        done
+
+        if [ "$missing" -ne 0 ]; then
+          exit 1
+        fi
+
+        echo "Verified ${FIRST_TAG} advertises: ${EXPECTED_PLATFORMS}"

--- a/scripts/compute-tags.sh
+++ b/scripts/compute-tags.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Single source of truth for Plane image tag policy.
+#
+# Both build-push and merge-manifest call this, so a per-arch build and the
+# manifest merge that tags it can never disagree about what the tag should be.
+# If this logic is ever duplicated instead, drift silently publishes images
+# under tags that the release notes and compose files do not reference.
+#
+# Reads configuration from the environment (all optional unless noted):
+#   IMG_OWNER                 required, e.g. makeplane
+#   IMG_NAME                  required, e.g. web-commercial
+#   BUILD_RELEASE             "true" selects the release tag regime
+#   IS_PRERELEASE             "true" suppresses the :stable tag on a release
+#   REL_VERSION               semver, required when BUILD_RELEASE=true
+#   TARGET_BRANCH             github.ref_name; "master" selects the :latest regime
+#   PRIVATE_REGISTRY_PUSH     "true" duplicates every tag into the private registry
+#   PRIVATE_REGISTRY_ADDR     e.g. registry.plane.tools
+#   PRIVATE_REGISTRY_PROJECT  e.g. plane
+#   FIPS_DOCKER_FILE_PATH     when non-empty, also computes the -fips tag list
+#
+# Writes DOCKER_TAGS (and DOCKER_TAGS_FIPS when applicable) to both $GITHUB_ENV
+# and $GITHUB_OUTPUT, and echoes them for the job log.
+
+set -euo pipefail
+
+: "${IMG_OWNER:?IMG_OWNER is required}"
+: "${IMG_NAME:?IMG_NAME is required}"
+
+BUILD_RELEASE="${BUILD_RELEASE:-false}"
+IS_PRERELEASE="${IS_PRERELEASE:-false}"
+REL_VERSION="${REL_VERSION:-latest}"
+TARGET_BRANCH="${TARGET_BRANCH:-}"
+PRIVATE_REGISTRY_PUSH="${PRIVATE_REGISTRY_PUSH:-false}"
+PRIVATE_REGISTRY_ADDR="${PRIVATE_REGISTRY_ADDR:-registry.plane.tools}"
+PRIVATE_REGISTRY_PROJECT="${PRIVATE_REGISTRY_PROJECT:-plane}"
+FIPS_DOCKER_FILE_PATH="${FIPS_DOCKER_FILE_PATH:-}"
+
+# Strip anything that is not legal in a docker tag. Branch names routinely
+# carry slashes (feat/PAI-123-thing), which would otherwise be read as a
+# registry path separator.
+FLAT_BRANCH_VERSION=$(printf '%s' "$TARGET_BRANCH" | sed 's/[^a-zA-Z0-9.-]//g')
+
+# Validate up front, not inside compute_tags_for: that function is called from a
+# command substitution, where `exit 1` would only kill the subshell.
+if [ "$BUILD_RELEASE" == "true" ]; then
+  SEMVER_REGEX="^v([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)?$"
+  if [[ ! $REL_VERSION =~ $SEMVER_REGEX ]]; then
+    echo "Invalid Release Version Format : ${REL_VERSION}" >&2
+    echo "Please provide a valid SemVer version" >&2
+    echo "e.g. v1.2.3 or v1.2.3-alpha-1" >&2
+    echo "Exiting the build process" >&2
+    exit 1
+  fi
+fi
+
+# Emits the comma-separated tag list for one image name, following whichever
+# regime the build type selects. Kept as a function so the regular and -fips
+# image names cannot drift apart.
+compute_tags_for() {
+  local name="$1"
+  local tags
+
+  if [ "$BUILD_RELEASE" == "true" ]; then
+    tags="${IMG_OWNER}/${name}:${REL_VERSION}"
+    if [ "$PRIVATE_REGISTRY_PUSH" == "true" ]; then
+      tags="${tags},${PRIVATE_REGISTRY_ADDR}/${PRIVATE_REGISTRY_PROJECT}/${name}:${REL_VERSION}"
+    fi
+
+    if [ "$IS_PRERELEASE" != "true" ]; then
+      tags="${tags},${IMG_OWNER}/${name}:stable"
+      if [ "$PRIVATE_REGISTRY_PUSH" == "true" ]; then
+        tags="${tags},${PRIVATE_REGISTRY_ADDR}/${PRIVATE_REGISTRY_PROJECT}/${name}:stable"
+      fi
+    fi
+  elif [ "$TARGET_BRANCH" == "master" ]; then
+    tags="${IMG_OWNER}/${name}:latest"
+    if [ "$PRIVATE_REGISTRY_PUSH" == "true" ]; then
+      tags="${tags},${PRIVATE_REGISTRY_ADDR}/${PRIVATE_REGISTRY_PROJECT}/${name}:latest"
+    fi
+  else
+    tags="${IMG_OWNER}/${name}:${FLAT_BRANCH_VERSION}"
+    if [ "$PRIVATE_REGISTRY_PUSH" == "true" ]; then
+      tags="${tags},${PRIVATE_REGISTRY_ADDR}/${PRIVATE_REGISTRY_PROJECT}/${name}:${FLAT_BRANCH_VERSION}"
+    fi
+  fi
+
+  printf '%s' "$tags"
+}
+
+emit() {
+  local key="$1" value="$2"
+  echo "${key}=${value}"
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "${key}=${value}" >>"$GITHUB_ENV"
+  fi
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "${key}=${value}" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+DOCKER_TAGS=$(compute_tags_for "$IMG_NAME")
+emit "DOCKER_TAGS" "$DOCKER_TAGS"
+
+if [ -n "$FIPS_DOCKER_FILE_PATH" ]; then
+  DOCKER_TAGS_FIPS=$(compute_tags_for "${IMG_NAME}-fips")
+  emit "DOCKER_TAGS_FIPS" "$DOCKER_TAGS_FIPS"
+fi


### PR DESCRIPTION
### Description

Lets one image be built by several jobs in parallel — one per architecture, each on a runner native to it — and merged afterwards into a single multi-arch manifest. This removes the need for QEMU emulation or a remote builder to produce arm64 images.

Prompted by `makeplane/plane-ee`, where the shared Docker Build Cloud endpoint (`makeplane/plane-dev`) has run out of disk and taken a GA release build down with it. That endpoint is shared with the CE workflow and has no owner.

**`build-push`** gains three opt-in inputs and three outputs:

| Input | Default | Effect |
| --- | --- | --- |
| `push-by-digest` | `"false"` | Pushes an untagged manifest and returns its digest instead of applying tags |
| `cache-scope-suffix` | `""` | Appended to the registry cache ref (`<image>:buildcache<suffix>`) |
| `digest-artifact-name` | `""` | Uploads the resulting digest under this artifact name for the merge job |

Outputs: `digest`, `tags`, `image-ref`.

**`merge-manifest`** is new. It collects the per-architecture digests, runs `docker buildx imagetools create` with one `-t` per tag, and then asserts the merged manifest really advertises the expected platforms.

**Tag policy moves to `scripts/compute-tags.sh`**, shared by both actions. If the merge re-implemented the release / master / branch regimes separately it could drift from the build and publish images under tags that release notes and compose files never reference.

### Backwards compatibility

Every new input is optional and defaults to reproducing v1.5.1 behaviour byte-for-byte. `plane-ee` pins `@v1.5.1` at ~40 call sites across three workflows; all of them are unaffected until they opt in individually.

Intended to ship as **v1.6.0**.

### Details worth reviewing

- `cache-scope-suffix` is effectively required when splitting. The registry cache manifest is not platform-indexed (docker/buildx#1044), so two legs writing the same `:buildcache` ref overwrite each other and roughly half the legs go cold every run.
- Digests travel as **artifacts, not job outputs**. Every matrix leg writes the same job-output key, so only the last leg to finish would survive — silently producing a single-platform manifest that looks like a success.
- `provenance` is pinned off in digest mode so each leg pushes a plain manifest rather than an index.
- `push-by-digest` rejects multi-platform input and `fips-docker-file-path` up front rather than failing deep inside BuildKit.
- The `Set Docker Tag` and `Copy License` steps no longer interpolate `${{ }}` expressions into shell bodies; they read environment variables instead.

### Type of Change

- [x] Feature (non-breaking change which adds functionality)
- [x] Improvement

### Test Scenarios

Verified end-to-end against a local `registry:2`:

1. Built `linux/amd64` and `linux/arm64` separately with the digest exporter — each returned a distinct digest via `containerimage.digest`.
2. Confirmed **no tag existed** in the registry between the builds and the merge.
3. `imagetools create` with two `-t` flags produced one OCI index tagged `preview` and `stable`, listing exactly `linux/amd64` and `linux/arm64`.
4. Confirmed the platform assertion **rejects** a single-arch manifest, and that `linux/arm` does not false-match `linux/arm64`.
5. Confirmed a single-digest merge (the amd64-only path, which is 19 of the last 20 `plane-ee` runs) still produces an index with a `Platform:` line, so the assertion holds there too.

`compute-tags.sh` was diffed against v1.5.1 across all eight regimes — branch, slashed branch, master, GA release, prerelease, private registry, FIPS list, and invalid semver — and reproduces the existing output exactly. `shellcheck` is clean; both `action.yml` files parse.

### References

- Consumer: `makeplane/plane-ee` — INFRA-484